### PR TITLE
Fix for when there's multiple examples for scalar field

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "npm run jsdoctest && mocha test/ --recursive",
+    "test": "npm run build-ts && npm run jsdoctest && mocha test/ --recursive",
     "build-ts": "tsc",
     "watch-ts": "tsc -w",
     "jsdoctest": "mocha --require jsdoctest lib/"

--- a/src/aqtToQuery.ts
+++ b/src/aqtToQuery.ts
@@ -21,7 +21,7 @@ export default function queryTreeToGraphQLString(tree, parentIndex = 0) {
     });
   }
 
-  if (_.isArray(tree) ){
+  if (_.isArray(tree)) {
     _.map(tree, (item, index) => {
       output += `${queryTreeToGraphQLString(item, parentIndex + index)} `;
     });

--- a/src/aqtToQuery.ts
+++ b/src/aqtToQuery.ts
@@ -2,11 +2,12 @@ import * as _ from 'lodash';
 
 /**
  * @example
- *   exports.default('name') // => 'name'
- *   exports.default(['name', 'surname', 'age']) // => 'name surname age '
- *   exports.default({ people: 'name', countries: ['flag']}) // => 'q0_42: people { name }q0_43: countries { flag  }'
+ *   exports.default('name') // => 'f0: name'
+ *   exports.default(['name', 'surname', 'age']) // => 'f0: name f1: surname f2: age '
+ *   exports.default(['name', 'name', 'name']) // => 'f0: name f1: name f2: name '
+ *   exports.default({ people: 'name', countries: ['flag']}) // => 'q0_42: people { f42: name }q0_43: countries { f43: flag  }'
  *   exports.default(['id', 'name', { coordinates: ['lat', 'long'] }, { test: ['a']}])
- *   // => 'id name q2_42: coordinates { lat long  } q3_42: test { a  } '
+ *   // => 'f0: id f1: name q2_42: coordinates { f42: lat f43: long  } q3_42: test { f42: a  } '
  */
 export default function queryTreeToGraphQLString(tree, parentIndex = 0) {
   let output : string = '';
@@ -20,14 +21,14 @@ export default function queryTreeToGraphQLString(tree, parentIndex = 0) {
     });
   }
 
-  if (_.isArray(tree)) {
+  if (_.isArray(tree) ){
     _.map(tree, (item, index) => {
-      output += `${queryTreeToGraphQLString(item, index)} `;
+      output += `${queryTreeToGraphQLString(item, parentIndex + index)} `;
     });
   }
 
   if (_.isString(tree)) {
-    output = `${tree}`;
+    output = `f${parentIndex}: ${tree}`;
   }
 
   return output;

--- a/src/schemaToQueryTree.ts
+++ b/src/schemaToQueryTree.ts
@@ -182,7 +182,7 @@ export default {
         return null;
       }
 
-      return queriesForRootField.join(' ');
+      return queriesForRootField;
     }
 
     if (fieldTypeDefinition.kind === 'OBJECT') {

--- a/test/unit/schemaToQueryTree/schemaToQueryTreeBase.test.js
+++ b/test/unit/schemaToQueryTree/schemaToQueryTreeBase.test.js
@@ -18,7 +18,7 @@ describe('Build query tree from field', () => {
             args: []
         },
             typeDictionary
-        ).should.equal('FetchParentField');
+        ).should.deep.equal(['FetchParentField']);
     });
 
     it('should handle simple objects', () => {
@@ -32,8 +32,8 @@ describe('Build query tree from field', () => {
         },
             typeDictionary, ignoreList
         );
-        result.MyObjectField[0].should.equal('MyScalar');
-        result.MyObjectField[1].should.equal('MyScalar2');
+        result.MyObjectField[0].should.deep.equal(['MyScalar']);
+        result.MyObjectField[1].should.deep.equal(['MyScalar2']);
         ignoreList.length.should.equal(1);
         ignoreList[0].should.equal('MyObjectField-ObjectField-ROOT');
     });
@@ -50,9 +50,9 @@ describe('Build query tree from field', () => {
             typeDictionary, ignoreList
         );
         result.MyObjectWithNested[0].should.include.all.keys('NestedObject');
-        result.MyObjectWithNested[0].NestedObject[0].should.equal('MyScalar');
-        result.MyObjectWithNested[0].NestedObject[1].should.equal('MyScalar2');
-        result.MyObjectWithNested[1].should.equal('NestedScalar');
+        result.MyObjectWithNested[0].NestedObject[0].should.deep.equal(['MyScalar']);
+        result.MyObjectWithNested[0].NestedObject[1].should.deep.equal(['MyScalar2']);
+        result.MyObjectWithNested[1].should.deep.equal(['NestedScalar']);
         ignoreList.length.should.equal(2);
         ignoreList[0].should.equal('MyObjectWithNested-ObjectNestingOtherObject-ROOT');
         ignoreList[1].should.equal('NestedObject-ObjectField-ObjectNestingOtherObject');
@@ -73,7 +73,7 @@ describe('Build query tree from field', () => {
         result.MyCircle[0].should.include.all.keys('DeepNest');
         result.MyCircle[0].DeepNest.length.should.equal(1);
         result.MyCircle[0].DeepNest[0].NotSoDeepNest.length.should.equal(2);
-        result.MyCircle[0].DeepNest[0].NotSoDeepNest[0].should.equal('MyScalar');
+        result.MyCircle[0].DeepNest[0].NotSoDeepNest[0].should.deep.equal(['MyScalar']);
     });
 
     it('should handle very similar objects[test covering skipList naming bug]', () => {
@@ -129,8 +129,8 @@ describe('Build query tree from field', () => {
         },
             typeDictionary
         );
-        result['MyObjectField(ip: "192.168.0.1")'][0].should.equal('MyScalar');
-        result['MyObjectField(ip: "192.168.0.1")'][1].should.equal('MyScalar2');
+        result['MyObjectField(ip: "192.168.0.1")'][0].should.deep.equal(['MyScalar']);
+        result['MyObjectField(ip: "192.168.0.1")'][1].should.deep.equal(['MyScalar2']);
     });
 
     it('should ignore nullable args', () => {
@@ -149,8 +149,8 @@ describe('Build query tree from field', () => {
         },
             typeDictionary
         );
-        result.MyObjectField[0].should.equal('MyScalar');
-        result.MyObjectField[1].should.equal('MyScalar2');
+        result.MyObjectField[0].should.deep.equal(['MyScalar']);
+        result.MyObjectField[1].should.deep.equal(['MyScalar2']);
     });
 
     it('should ignore nullable args for SCALAR fields', () => {
@@ -169,7 +169,7 @@ describe('Build query tree from field', () => {
         },
             typeDictionary
         );
-        result.should.equal('MyScalar');
+        result.should.deep.equal(['MyScalar']);
     });
 
     it('should use single example from description for non-nullable args for SCALAR fields', () => {
@@ -189,7 +189,7 @@ describe('Build query tree from field', () => {
         },
             typeDictionary
         );
-        result.should.equal('MyScalar(ip: "192.168.0.1")');
+        result.should.deep.equal(['MyScalar(ip: "192.168.0.1")']);
     });
 
     it('should use multiple examples from description for non-nullable args for SCALAR fields', () => {
@@ -209,6 +209,6 @@ describe('Build query tree from field', () => {
         },
             typeDictionary
         );
-        result.should.equal('MyScalar(ip: "192.168.0.1") MyScalar(ip: "192.168.0.2")');
+        result.should.deep.equal(['MyScalar(ip: "192.168.0.1")','MyScalar(ip: "192.168.0.2")']);
     });
 });


### PR DESCRIPTION
`schemaToQueryTree` will now return arrays for scalars so that `aqtToQuery` can reason about numbering fields to ensure there's no duplicate names