### PR TITLE
Include field name in alias for better readability

### DIFF
--- a/src/aqtToQuery.ts
+++ b/src/aqtToQuery.ts
@@ -1,22 +1,25 @@
-import * as _ from 'lodash';
+import * as _ from "lodash";
 
 /**
  * @example
- *   exports.default('name') // => 'f0: name'
- *   exports.default(['name', 'surname', 'age']) // => 'f0: name f1: surname f2: age '
- *   exports.default(['name', 'name', 'name']) // => 'f0: name f1: name f2: name '
- *   exports.default({ people: 'name', countries: ['flag']}) // => 'q0_42: people { f42: name }q0_43: countries { f43: flag  }'
+ *   exports.default('name') // => 'f0_name: name'
+ *   exports.default(['name', 'surname', 'age']) // => 'f0_name: name f1_surname: surname f2_age: age '
+ *   exports.default(['name', 'name', 'name']) // => 'f0_name: name f1_name: name f2_name: name '
+ *   exports.default({ people: 'name', countries: ['flag']}) // => 'q0_42_people: people { f42_name: name }q0_43_countries: countries { f43_flag: flag  }'
  *   exports.default(['id', 'name', { coordinates: ['lat', 'long'] }, { test: ['a']}])
- *   // => 'f0: id f1: name q2_42: coordinates { f42: lat f43: long  } q3_42: test { f42: a  } '
+ *   // => 'f0_id: id f1_name: name q2_42_coordinates: coordinates { f42_lat: lat f43_long: long  } q3_42_test: test { f42_a: a  } '
  */
 export default function queryTreeToGraphQLString(tree, parentIndex = 0) {
-  let output : string = '';
+  let output: string = "";
 
   if (_.isObject(tree) && !_.isArray(tree)) {
-    let index : number = 42;
+    let index: number = 42;
     _.forIn(tree, (value, key) => {
       var x = tree == tree;
-      output += `q${parentIndex}_${index}: ${key} { ${queryTreeToGraphQLString(value, index)} }`;
+      output += `q${parentIndex}_${index}_${key}: ${key} { ${queryTreeToGraphQLString(
+        value,
+        index
+      )} }`;
       index++;
     });
   }
@@ -28,9 +31,8 @@ export default function queryTreeToGraphQLString(tree, parentIndex = 0) {
   }
 
   if (_.isString(tree)) {
-    output = `f${parentIndex}: ${tree}`;
+    output = `f${parentIndex}_${tree}: ${tree}`;
   }
 
   return output;
-};
-
+}

--- a/test/acceptance/commentTests.js
+++ b/test/acceptance/commentTests.js
@@ -1,52 +1,49 @@
-const should = require('chai').should();
-const app = require('./exampleServer');
-const QueryGenerator = require('../../lib/queryGenerator');
+const should = require("chai").should();
+const app = require("./exampleServer");
+const QueryGenerator = require("../../lib/queryGenerator");
 
-describe('Query generation', () => {
-
-  const serverUrl = 'http://localhost:12345/graphql';
+describe("Query generation", () => {
+  const serverUrl = "http://localhost:12345/graphql";
   let queryPromise = null;
 
-  before(() => app.then(()=>{
-    const queryGenerator = new QueryGenerator(serverUrl);
-    queryPromise = queryGenerator.run();
-  }));
+  before(() =>
+    app.then(() => {
+      const queryGenerator = new QueryGenerator(serverUrl);
+      queryPromise = queryGenerator.run();
+    })
+  );
 
-  it('Generates multiple queries', () => {
-    return queryPromise
-        .then(({queries}) => {
-          (queries[0].match(/rollDice/g) || []).length.should.equal(4);
-        });
-
+  it("Generates multiple queries", () => {
+    return queryPromise.then(({ queries }) => {
+      (queries[0].match(/rollDice/g) || []).length.should.equal(8);
+    });
   });
 
-  it('Ignores fields with +NOFOLLOW in description', () => {
-    return queryPromise
-      .then(({queries, coverage}) => {
-        (queries[0].match(/ignoredWithExamples/g) || []).length.should.equal(0);
-        (queries[0].match(/ignoredNoParameters/g) || []).length.should.equal(0);
-      });
+  it("Ignores fields with +NOFOLLOW in description", () => {
+    return queryPromise.then(({ queries, coverage }) => {
+      (queries[0].match(/ignoredWithExamples/g) || []).length.should.equal(0);
+      (queries[0].match(/ignoredNoParameters/g) || []).length.should.equal(0);
+    });
   });
 
-  it('Uses Examples section for scalar fields with non-nullable args', () => {
-    return queryPromise
-      .then(({queries}) => {
-        // 8 because we have two examples for rollXTimes and 4 examples of parent
-        (queries[0].match(/rollXTimes\(times. [0-9]+\)/g) || []).length.should.equal(8);
-      });
+  it("Uses Examples section for scalar fields with non-nullable args", () => {
+    return queryPromise.then(({ queries }) => {
+      // 8 because we have two examples for rollXTimes and 4 examples of parent
+      (
+        queries[0].match(/rollXTimes\(times. [0-9]+\)/g) || []
+      ).length.should.equal(16);
+    });
   });
 
-  it('Calculates valid coverage', () => {
-    return queryPromise
-      .then(({coverage}) => {
-        coverage.coverageRatio.should.be.at.least(0);
-        coverage.coverageRatio.should.be.at.most(1);
-        if(coverage.coverageRatio < 1.0) {
-          coverage.notCoveredFields.length.should.be.at.least(1);
-        } else {
-          coverage.notCoveredFields.length.should.equal(0);
-        }
-      });
+  it("Calculates valid coverage", () => {
+    return queryPromise.then(({ coverage }) => {
+      coverage.coverageRatio.should.be.at.least(0);
+      coverage.coverageRatio.should.be.at.most(1);
+      if (coverage.coverageRatio < 1.0) {
+        coverage.notCoveredFields.length.should.be.at.least(1);
+      } else {
+        coverage.notCoveredFields.length.should.equal(0);
+      }
+    });
   });
-
 });


### PR DESCRIPTION
When looking at the output of the test queries we run, we want to be able to see the field name so we know what is generating the output without trying to trace our way back.